### PR TITLE
[DO NOT MERGE YET] README: Booting from the external microSD card

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,49 @@ sync
 
 Booting from the external microSD card
 --------------------------------------
-TODO
+
+* Insert the external microSD card in the ereader and boot it up.
+
+* Get a shell on the device, either via Telnet, SSH or some sort of terminal emulator.
+
+* On the ereader shell, mount the rootfs as read only and clone the internal memory into the external microSD card:
+
+```
+umount /mnt/onboard
+mount -o remount,ro /
+dd if=/dev/mmcblk0 of=/dev/mmcblk1
+```
+
+* Remount the filesystems with their default options:
+
+```
+mount -o remount,rw /
+mount -t vfat -o noatime,nodiratime,shortname=mixed,utf8 /dev/mmcblk0p3 /mnt/onboard
+```
+
+* Remove the microSD card from the ereader and insert it into a computer with a microSD card reader.
+
+* Extract the hardware configuration block from the microSD card. For example, on a GNU/Linux computer, assuming the SD card is at /dev/mmcblk0 (replace as needed):
+
+```
+dd bs=512 skip=1024 count=1 if=/dev/mmcblk0 of=ereader.hwconfig
+```
+
+* Use a hex editor to change the byte at offset 0x3F (63) from 0 to 1:
+
+```
+printf '\x01' | dd of=ereader.hwconfig bs=1 seek=63 count=1 conv=notrunc
+```
+
+* Write it back to the microSD card
+
+```
+dd if=ereader.hwconfig bs=512 seek=1024 of=/dev/mmcblk0
+```
+
+* Proceed with the installation as documented in **Installation on the internal microSD**.
+
+* Hold down the power and backlight buttons while booting until the LED is blinking to boot from the external microSD card.
 
 
 Notes for developers


### PR DESCRIPTION
Howdy.

I have recently acquired a Kobo Aura which does not have an internal microSD card, but instead a embedded BGA chip for storage.

After scouring the internet looking for documentation on how to boot from the external microSD I was able to get okreader running from it without any apparent issues.

This PR documents the most important steps I took in order to accomplish this and I would like some feedback on a few issues.

For instance, I do not know if the process through which one acquires a shell should be detailed in the README as most of the documentation and tools I came across didn't seem particularly trustworthy.

Is there a way to access a terminal emulator on Nikel? What is the recommended way to get an SSH or Telnet daemon on Nikel?

Additionally I came across some difficulties when booting from a formatted rootfs. 

```
Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(179,9)
```

It seems likely that my `mkfs.ext4` was including some options the ereader didn't like, or maybe I was doing something wrong, so for my installation I opted to purge all files from it instead of formatting. I believe this would affect anyone doing an internal microSD install as well.

Also, I have previously documented the cloning of the internal memory with `netcat` via telnet, but I believe its faster to do it directly.

Is anyone willing to try this out?

Thanks for your time and for maintaining okreader.